### PR TITLE
Fix education block alignment and redesign publication section

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1124,6 +1124,36 @@ section .container {
 }
 
 /*--------------------------------------------------------------
+# Publication List
+--------------------------------------------------------------*/
+.publication-list {
+  padding-left: 1.2rem;
+}
+
+.publication-list li {
+  margin-bottom: 1.2rem;
+  line-height: 1.6;
+}
+
+.publication-list li a {
+  color: #fff;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.publication-list li a:hover {
+  color: #ffc107;
+  text-decoration: underline;
+}
+
+.pub-venue {
+  display: block;
+  color: #ffc107;
+  font-size: 0.9rem;
+  margin-top: 0.2rem;
+}
+
+/*--------------------------------------------------------------
 # Utility Classes
 --------------------------------------------------------------*/
 .text-left { text-align: left; }

--- a/index.html
+++ b/index.html
@@ -183,10 +183,10 @@
       <div class="section-title">
         <h2>Education</h2>
       </div>
-      <div class="row">
-        <div class="col-lg-12 inline-block" data-aos="fade-up">
+      <div class="row d-flex align-items-stretch" data-aos="fade-up">
 
-            <div class="col-md-4 mt-4 mt-md-0 icon-box inline-block pb-5px" data-aos="fade-up" data-aos-delay="100">
+          <div class="col-md-6 mt-4 d-flex" data-aos="fade-up" data-aos-delay="100">
+            <div class="icon-box w-100">
               <img src="assets/img/education/cds.jpg" class="img-fluid" alt="">
               <p class="text-left color-white" style="padding: 5px 10px;"><em>MS in Data Science</em></p>
               <h5 class="text-left" style="padding: 0px 10px;">September 2022 - Present</h5>
@@ -199,7 +199,9 @@
                 <li>Natural Language Processing and Representation Learning</li>
               </ul>
             </div>
-            <div class="col-md-4 mt-4 mt-md-0 icon-box inline-block pb-5px" data-aos="fade-up" data-aos-delay="100">
+          </div>
+          <div class="col-md-6 mt-4 d-flex" data-aos="fade-up" data-aos-delay="100">
+            <div class="icon-box w-100">
               <img src="assets/img/education/NTHU.jpg" class="img-fluid" alt="">
               <p class="text-left color-white" style="padding: 5px 10px;"><em>B.S.M. in Quantitative Finance</em></p>
               <h5 class="text-left" style="padding: 0px 10px;">September 2017 - June 2021</h5>
@@ -216,40 +218,28 @@
       </div>
 
 
-    <div class="portfolio">
     <div class="container">
       <div class="section-title">
         <h2>Publication</h2>
       </div>
-
-      <div class="row portfolio-container" style="position: relative; height: 437.75px;">
-
-        <div class="col-lg-4 col-md-6 portfolio-item filter-app">
-          <center><h4 class="fs-20">Predicting Risk of Alzheimer's Diseases and Related Dementias with AI Foundation Model on Electronic Health Records</h4></center>
-          <div class="portfolio-wrap">
-            <img src="assets/img/education/Med.png" class="img-fluid" alt="">
-            <div class="portfolio-info">
-              <div class="portfolio-links">
-                <a href="https://pubmed.ncbi.nlm.nih.gov/38712223/" target="_blank" title="Certificate"><i class="bx bx-link"></i></a>
-              </div>
-            </div>
-          </div>
+      <div class="row" data-aos="fade-up">
+        <div class="col-lg-12">
+          <ol class="publication-list">
+            <li>
+              <a href="https://pubmed.ncbi.nlm.nih.gov/38712223/" target="_blank">
+                Predicting Risk of Alzheimer's Diseases and Related Dementias with AI Foundation Model on Electronic Health Records
+              </a>
+              <span class="pub-venue">AMIA Annual Symposium, 2024</span>
+            </li>
+            <li>
+              <a href="https://www.mdpi.com/2071-1050/15/14/11435" target="_blank">
+                Structural Equation Modeling of the Marine Ecological System in Nanwan Bay Using SPSS Amos
+              </a>
+              <span class="pub-venue">Sustainability, 2023</span>
+            </li>
+          </ol>
         </div>
-
-      <div class="col-lg-4 col-md-6 portfolio-item filter-app">
-          <center><h4 class="fs-20">Structural Equation Modeling of the Marine Ecological System in Nanwan Bay Using SPSS Amos</h4></center>
-          <div class="portfolio-wrap">
-            <img src="assets/img/education/Sustain.jpg" class="img-fluid" alt="">
-            <div class="portfolio-info">
-              <div class="portfolio-links">
-                <a href="https://www.mdpi.com/2071-1050/15/14/11435" target="_blank" title="Certificate"><i class="bx bx-link"></i></a>
-              </div>
-            </div>
-           </div>
-        </div>
-
       </div>
-    </div>
     </div>
 
   </section>


### PR DESCRIPTION
- Education: switched from inline-block to Bootstrap flex row (d-flex align-items-stretch) with col-md-6 per school so both blocks stretch to the same height
- Publication: removed portfolio card/image layout; replaced with a numbered academic-list style where each title is a clickable link and the journal/year appears below in accent color
- style.css: added .publication-list and .pub-venue styles

https://claude.ai/code/session_01QWwBmjpUUq1HaKMFtMca4m